### PR TITLE
Fix typo in mongoose-store.coffee

### DIFF
--- a/lib/mongoose-store.coffee
+++ b/lib/mongoose-store.coffee
@@ -6,7 +6,7 @@ module.exports = (session) ->
   class MongooseStore extends session.Store
     constructor: (@options = {}) ->
       mongoose.connect @options.url if mongoose.connection.readyState is 0
-      @SessionModel = require('./model-session') options.ttl
+      @SessionModel = require('./model-session') @options.ttl
 
 
     get: (sid, callback) ->


### PR DESCRIPTION
The module does not work. 

/home/opssym/xxx/node_modules/mongoose-store/lib/mongoose-store.coffee:19
        this.SessionModel = require('./model-session')(options.ttl);
                                                       ^
ReferenceError: options is not defined
